### PR TITLE
web: Add Hilbert map

### DIFF
--- a/NERDweb/nerd_main.py
+++ b/NERDweb/nerd_main.py
@@ -1242,6 +1242,10 @@ def iplist():
         return Response('ERROR: Database connection error', 503, mimetype='text/plain')
 
 
+# ******************** Map ********************
+@app.route('/map/')
+def map():
+    return render_template("map.html", **locals())
 
 # ******************** Static/precomputed data ********************
 

--- a/NERDweb/nerd_main.py
+++ b/NERDweb/nerd_main.py
@@ -1244,7 +1244,7 @@ def iplist():
 
 # ******************** Map ********************
 @app.route('/map/')
-def map():
+def map_index():
     return render_template("map.html", **locals())
 
 # ******************** Static/precomputed data ********************

--- a/NERDweb/templates/layout.html
+++ b/NERDweb/templates/layout.html
@@ -135,7 +135,7 @@ hsl({{ '%i, 100%%, 90%%'|format(100 - 100*rep) if rep is defined else '0, 0%, 70
   {%- if config.logo_link %}</a>{% endif -%}
  </div>
  <div id="navigation">
-  <a href="{{ url_for('ips') }}">IP search</a> | <a href="{{ url_for('ip') }}">IP detail</a> | <a href="{{ url_for('data_index') }}">Data</a>
+  <a href="{{ url_for('ips') }}">IP search</a> | <a href="{{ url_for('ip') }}">IP detail</a> | <a href="{{ url_for('data_index') }}">Data</a> | <a href="{{ url_for('map') }}">Map</a>
  </div>
  <div id="login">
   {% if not user %}

--- a/NERDweb/templates/layout.html
+++ b/NERDweb/templates/layout.html
@@ -135,7 +135,7 @@ hsl({{ '%i, 100%%, 90%%'|format(100 - 100*rep) if rep is defined else '0, 0%, 70
   {%- if config.logo_link %}</a>{% endif -%}
  </div>
  <div id="navigation">
-  <a href="{{ url_for('ips') }}">IP search</a> | <a href="{{ url_for('ip') }}">IP detail</a> | <a href="{{ url_for('data_index') }}">Data</a> | <a href="{{ url_for('map') }}">Map</a>
+  <a href="{{ url_for('ips') }}">IP search</a> | <a href="{{ url_for('ip') }}">IP detail</a> | <a href="{{ url_for('data_index') }}">Data</a> | <a href="{{ url_for('map_index') }}">Map</a>
  </div>
  <div id="login">
   {% if not user %}

--- a/NERDweb/templates/map.html
+++ b/NERDweb/templates/map.html
@@ -1,0 +1,10 @@
+{% extends "layout.html" %}
+{% block body %}
+
+<h1>Visualization of IPv4 address space</h1>
+
+<p>Visualization uses Hilbert curve to display IPv4 address space. Pixel on visualization represents a certain network and its value is sum of reputation scores of IP addresses in given network. </p>
+<iframe src="http://ipvizualizator.sh.cvut.cz/map.html" scrolling="no" width="1000" height="900" style="border:none;">
+</iframe>
+
+{% endblock %}


### PR DESCRIPTION
Add page with visualization of IPv4 address space on NERD web. Visualization uses Hilbert curve to display IPv4 address space. Pixel on visualization represents a certain network and its value is sum of reputation scores of IP addresses in given network. 

It uses iframe for displaying visualization. It is probably a temporary solution but it is the quickest one due to the remaining time.