### PR TITLE
fix the shodan api config

### DIFF
--- a/NERDd/modules/shodan.py
+++ b/NERDd/modules/shodan.py
@@ -42,7 +42,7 @@ class Shodan(NERDModule):
         self.errors = 0 # Number of API errors that has occurred
         self.enabled = True
         
-        self.apikey = g.config.get('shodan.apikey', None)
+        self.apikey = g.config.get('shodan_api_key', None)
         if not self.apikey:
             self.log.warning("No API key set, Shodan module disabled.")
             return

--- a/etc/nerdd.yml
+++ b/etc/nerdd.yml
@@ -98,9 +98,6 @@ fmp:
   paths: {"general" : "/data/fmp/general/"}
   models: {"general" : "/data/fmp/models/model_access_nerd_xg200_7.bin"}
 
-#shodan:
-#   apikey: ""
-
 dshield:
   # DShield requires to include contact information in the User-Agent header of API requests
   # (see https://www.dshield.org/api).


### PR DESCRIPTION
[fix the shodan api config] there are two shodan api parameters in configuration files, `nerd.yml` and `nerdd.yml`, seperately. One was used in shodan_rpc and another was used in shodan module.

This commit merges them into one.